### PR TITLE
Doc: add new schedule merge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@
 ##### Links:
 - [Actions Merge Schedule](https://github.com/marketplace/actions/merge-schedule)
 - [Cron](https://crontab.guru/every-hour)
+- [Automatically schedule a git merge using GitHub Actions](https://www.sean-lloyd.com/post/schedule-git-merges-with-github-actions/)


### PR DESCRIPTION
## Doc: add new schedule merge link

Link: [Automatically schedule a git merge using GitHub Actions](https://www.sean-lloyd.com/post/schedule-git-merges-with-github-actions/)

/schedule 2022-02-08T18:05:00.000